### PR TITLE
ADD: new variable, that triggers the use of a second network, if it i…

### DIFF
--- a/30_create_instance.tf
+++ b/30_create_instance.tf
@@ -11,4 +11,11 @@ resource "openstack_compute_instance_v2" "instances" {
   network {
     port = openstack_networking_port_v2.instance_ports[count.index].id
   }
+
+  dynamic "network" {
+    for_each = var.instance_id_of_second_network ? [var.instance_id_of_second_network] : []
+    content {
+      uuid = network.value
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -67,3 +67,8 @@ variable "instance_config_drive" {
   description = "Whether or not to use a ConfigDrive for the new instance"
   default     = false
 }
+
+variable "instance_id_of_second_network" {
+  description = "ID of the second network to use for the instance"
+  default = false
+}


### PR DESCRIPTION
…s set to the ID of this second network. Default is: only one network