### PR TITLE
BUGFIX: terraform syntax woes

### DIFF
--- a/30_create_instance.tf
+++ b/30_create_instance.tf
@@ -13,7 +13,7 @@ resource "openstack_compute_instance_v2" "instances" {
   }
 
   dynamic "network" {
-    for_each = var.instance_id_of_second_network ? [var.instance_id_of_second_network] : []
+    for_each = var.instance_id_of_second_network == "" ? [] : [var.instance_id_of_second_network]
     content {
       uuid = network.value
     }

--- a/variables.tf
+++ b/variables.tf
@@ -70,5 +70,5 @@ variable "instance_config_drive" {
 
 variable "instance_id_of_second_network" {
   description = "ID of the second network to use for the instance"
-  default = false
+  default = ""
 }


### PR DESCRIPTION
as terraform does not recognize 'not false' as a valid true condition, set the default to being an empty string and check for that